### PR TITLE
Fix Chinese translation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
         <item>Français</item>
         <item>Español</item>
         <item>简体中文</item>
-        <item>中国传统</item>
+        <item>正體中文</item>
         <item>한국어</item>
     </string-array>
     <string-array name="language_values" translatable="false">
@@ -63,7 +63,7 @@
         <item>ru</item>
         <item>fr</item>
         <item>es</item>
-        <item>zh</item>
+        <item>zh-rCN</item>
         <item>zh-rTW</item>
         <item>ko</item>
     </string-array>


### PR DESCRIPTION
Traditional Chinese translation does not work, this should fix that. See: [Kernel Adiutor](https://github.com/Grarak/KernelAdiutor/tree/master/app/src/main/res)
Note traditional Chinese should be 正體中文, that is what many other apps does anyway.